### PR TITLE
Prevent layout problems

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,8 @@ href="https://github.com/jermar/microkernel.info/issues/new">let us
 know</a>!</p>
 
 		<div class="projects">
+			<div class="left">
+
 			<div class="project genode">
 				<img src="img/genode.png"/>
 				<div class="desc">
@@ -62,6 +64,9 @@ know</a>!</p>
 				</div>
 			</div>
 
+			</div>
+			<div class="right">
+
 			<div class="project minix3">
 				<img src="img/minix3.jpg"/>
 				<div class="desc">
@@ -92,6 +97,8 @@ know</a>!</p>
 					<h2>seL4</h2>
 					<p>A high-assurance, high-performance microkernel developed, maintained and formally verified by NICTA and owned by General Dynamics C4 Systems. It is a member of the L4 family of microkernels, and is the world's most advanced, highest-assured operating-system microkernel. (<a href="http://sel4.systems">sel4.systems</a>)</p>
 				</div>
+			</div>
+
 			</div>
 
 		</div>

--- a/styles.css
+++ b/styles.css
@@ -28,9 +28,16 @@ div.projects {
 	margin-left: auto;
 	margin-right: auto;
 	width: 1200px;
-	column-count: 2;
-	-webkit-column-count: 2;
-	-moz-column-count: 2;
+}
+
+.projects .left {
+	float: left;
+	width: 600px;
+}
+
+.projects .right {
+	float: right;
+	width: 600px;
 }
 
 div.project {


### PR DESCRIPTION
Chromium seems to have some trouble with column-count in
some cases. Using float is better supported in the
browsers and achieves basically the same result.

The disadvantage is that we might have to manually move projects to
re-balance the columns if projects are added, though.
